### PR TITLE
Fix barrier histogram

### DIFF
--- a/cemc/mcmc/__init__.py
+++ b/cemc/mcmc/__init__.py
@@ -12,3 +12,4 @@ from nucleation_sampler import NucleationSampler
 from sgc_nucleation_mc import SGCNucleation
 from canonical_nucleation_mc import CanonicalNucleationMC
 from fixed_nucleation_size_sampler import FixedNucleusMC
+from sgc_free_energy_barrier import SGCFreeEnergyBarrier

--- a/cemc/mcmc/sgc_free_energy_barrier.py
+++ b/cemc/mcmc/sgc_free_energy_barrier.py
@@ -156,8 +156,8 @@ class SGCFreeEnergyBarrier( SGCMonteCarlo ):
         """
         Stores the results to a JSON file
         """
+        self.get_merged_records()
         if ( self.rank == 0 ):
-            self.get_merged_records()
             self.result["temperature"] = self.T
             self.result["chemical_potential"] = self.chemical_potential
             x = np.linspace(self.min_singlet,self.max_singlet,len(self.result["free_energy"]))

--- a/cemc/mcmc/sgc_free_energy_barrier.py
+++ b/cemc/mcmc/sgc_free_energy_barrier.py
@@ -212,15 +212,15 @@ class SGCFreeEnergyBarrier( SGCMonteCarlo ):
         """
         with open(fname,'r') as infile:
             result = json.load(infile)
-        print ("Temperature: {}K".format(result["Temperature"]))
-        print ("Chemical potential: {}K".format(result["chem_pot"]) )
+        print ("Temperature: {}K".format(result["temperature"]))
+        print ("Chemical potential: {}K".format(result["chemical_potential"]) )
 
         figs = []
         figs.append( plt.figure() )
         ax = figs[-1].add_subplot(1,1,1)
         ax.plot( result["xaxis"], result["free_energy"], ls="steps" )
         ax.set_xlabel( "Singlets" )
-        ax.set_ylabel( "Free energy (eV)" )
+        ax.set_ylabel( "$\\beta \Delta G$" )
 
         figs.append( plt.figure() )
         ax = figs[-1].add_subplot(1,1,1)

--- a/cemc/mcmc/sgc_free_energy_barrier.py
+++ b/cemc/mcmc/sgc_free_energy_barrier.py
@@ -34,13 +34,14 @@ class SGCFreeEnergyBarrier( SGCMonteCarlo ):
             max_singlet = kwargs.pop("max_singlet")
         if ( "mpicomm" in kwargs.keys() ):
             self.free_eng_mpi = kwargs.pop("mpicomm")
-        if ( self.free_eng_mpi is not None ):
-            self.rank = self.free_eng_mpi.Get_rank()
         self.n_windows = n_windows
         self.n_bins = n_bins
         self.min_singlet = min_singlet
         self.max_singlet = max_singlet
         super( SGCFreeEnergyBarrier, self ).__init__( atoms, T, **kwargs)
+
+        if ( self.free_eng_mpi is not None ):
+            self.rank = self.free_eng_mpi.Get_rank()
 
         # Set up whats needed
         self.window_singletrange = (self.max_singlet - self.min_singlet)/self.n_windows

--- a/cemc/mcmc/sgc_free_energy_barrier.py
+++ b/cemc/mcmc/sgc_free_energy_barrier.py
@@ -13,6 +13,8 @@ from cemc.mcmc.mc_observers import SGCObserver
 import numpy as np
 from matplotlib import pyplot as plt
 from ase.visualize import view
+import json
+import time
 
 class SGCFreeEnergyBarrier( SGCMonteCarlo ):
     def __init__( self, atoms, T, **kwargs):
@@ -20,6 +22,8 @@ class SGCFreeEnergyBarrier( SGCMonteCarlo ):
         n_bins = 5
         min_singlet = -1.0
         max_singlet = -0.4
+        self.free_eng_mpi = None
+        self.rank = 0
         if ( "n_windows" in kwargs.keys() ):
             n_windows = kwargs.pop("n_windows")
         if ( "n_bins" in kwargs.keys() ):
@@ -28,21 +32,89 @@ class SGCFreeEnergyBarrier( SGCMonteCarlo ):
             min_singlet = kwargs.pop("min_singlet")
         if ( "max_singlet" in kwargs.keys() ):
             max_singlet = kwargs.pop("max_singlet")
+        if ( "mpicomm" in kwargs.keys() ):
+            self.free_eng_mpi = kwargs.pop("mpicomm")
+        if ( self.free_eng_mpi is not None ):
+            self.rank = self.free_eng_mpi.Get_rank()
         self.n_windows = n_windows
         self.n_bins = n_bins
         self.min_singlet = min_singlet
         self.max_singlet = max_singlet
-        super( SGCFreeEnergyBarrier, self ).__init__( atoms, T, **kwargs)	
+        super( SGCFreeEnergyBarrier, self ).__init__( atoms, T, **kwargs)
 
-        # Set up whats needed 		
+        # Set up whats needed
         self.window_singletrange = (self.max_singlet - self.min_singlet)/self.n_windows
         self.bin_singletrange = self.window_singletrange / self.n_bins
-        # Set up data storage, all windows must have one bin extra, except the first one
-        self.data = [1] * (self.n_windows * (self.n_bins + 1) - 1)
-        self.energydata = [0] * (self.n_windows * (self.n_bins + 1) - 1)		
+        self.energydata = []
         self.current_window = 0
+        self.data = []
+        self.result = {}
+        for i in range(self.n_windows):
+            if ( i == 0 ):
+                self.data.append( np.ones(self.n_bins) )
+                self.energydata.append( np.zeros(self.n_bins) )
+            else:
+                self.data.append( np.ones(self.n_bins+1) )
+                self.energydata.append( np.zeros(self.n_bins+1) )
+
+    def get_window_limits( self, window ):
+        """
+        Returns the upper and lower bound for window
+        """
+        if ( window == 0 ):
+            min_limit = 0
+        else:
+            min_limit = window*self.window_singletrange - self.bin_singletrange
+
+        max_limit = (window+1)*self.window_singletrange
+        return min_limit, max_limit
+
+    def get_window_indx( self, window, value ):
+        """
+        Returns the index of value in the current window
+        """
+        min_lim, max_lim= self.get_window_limits(window)
+        if ( value < min_lim or value >= max_lim ):
+            msg = "Value out of range for window\n"
+            msg += "Value has to be in range [{},{})\n".format(min_lim,max_lim)
+            msg += "Got value: {}".format(value)
+            raise ValueError(msg)
+
+        if ( window == 0 ):
+            N = self.n_bins
+        else:
+            N = self.n_bins+1
+        indx = (value-min_lim)*N/(max_lim-min_lim)
+        return int(indx)
+
+    def collect_results( self ):
+        """
+        Collects the results from all processors
+        """
+        if ( self.free_eng_mpi is None ):
+            return
+        temp_data = []
+        temp_energy = []
+        for i in range(len(self.data)):
+            recv_buf = np.zeros_like(self.data[i])
+            self.free_eng_mpi.Allreduce( self.data[i], recv_buf )
+            temp_data.append(np.copy(recv_buf))
+            self.free_eng_mpi.Allreduce( self.energydata[i], recv_buf )
+            temp_energy.append( np.copy(recv_buf) )
+        self.data = temp_data
+        self.energydata = temp_energy
+
+    def update_records( self ):
+        """
+        Update the data arrays
+        """
+        singlet = self.averager.singlets[0]
+        indx = self.get_window_indx( self.current_window, singlet )
+        self.data[self.current_window][indx] += 1
+        self.energydata[self.current_window][indx] += self.current_energy
 
     def accept( self, system_changes ):
+
         # Check if move accepted by SGCMonteCarlo
         move_accepted = SGCMonteCarlo.accept(self, system_changes)
         # Now check if the move keeps us in same window
@@ -51,85 +123,107 @@ class SGCFreeEnergyBarrier( SGCMonteCarlo ):
         singlet = new_singlets[0]
         # Set in_window to True and check if it should be False instead
         in_window = True
-        if (self.current_window == 0):
-            # Now we are in first window
-            min_allowed = self.min_singlet
-        else:
-            #Now we are in a later window, must also allow the last bin from the previous window
-            min_allowed = self.min_singlet + self.current_window * self.window_singletrange - self.bin_singletrange 
-        # The maximum allowed singlet is calculated in the same way for both cases
-        max_allowed = self.min_singlet + (self.current_window + 1) * self.window_singletrange
+        min_allowed,max_allowed = self.get_window_limits(self.current_window)
+
         if (singlet < min_allowed or singlet > max_allowed):
             in_window = False
         # Now system will return to previous state if not inside window
         return move_accepted and in_window
 
+    def get_merged_records( self ):
+        """
+        Merge the records into a one array
+        """
+        self.collect_results()
+        all_data = self.data[0].tolist()
+        energy = (self.energydata[0]/self.data[0]).tolist()
+        for i in range(1,len(self.data)):
+            ratio = all_data[-1]/self.data[i][0]
+            self.data[i] *= ratio
+            all_data += self.data[i][1:].tolist()
+            energy += (self.energydata[i]/self.data[i])[1:].tolist()
+
+        all_data = np.array(all_data)
+        all_data /= all_data[0]
+        G = -np.log(all_data)
+        self.result["histogram"] = all_data.tolist()
+        self.result["free_energy"] = G.tolist()
+        self.result["energy"] = energy
+        return self.result
+
+    def save( self, fname="sgc_free_energy.json" ):
+        """
+        Stores the results to a JSON file
+        """
+        if ( self.rank == 0 ):
+            self.get_merged_records()
+            self.result["temperature"] = self.T
+            self.result["chemical_potential"] = self.chemical_potential
+            x = np.linspace(self.min_singlet,self.max_singlet,len(self.result["free_energy"]))
+            self.result["xaxis"] = x.tolist()
+
+            # Store also the raw histgramgs
+            self.result["raw_histograms"] = [hist.tolist() for hist in self.data]
+
+            with open( fname, 'w' ) as outfile:
+                json.dump( self.result, outfile, indent=2, separators=(",",":") )
+            self.log( "Results written to: {}".format(fname) )
+
+    def bring_system_into_window(self):
+        """
+        Brings the system into the current window
+        """
+        min_lim, max_lim = self.get_window_limits(self.current_window)
+        newsinglet = 0.5*(min_lim+max_lim)
+        self.atoms._calc.set_singlets({"c1_0":newsinglet})
+
     def run( self, nsteps = 10000, chem_pot = None ):
         # For all windows
         self.chemical_potential = chem_pot
+        output_every = 30
         for i in range(self.n_windows):
             self.current_window = i
             # We are inside a new window, update to start with concentration in the middle of this window
-            newsinglet = self.min_singlet + (self.current_window + 0.5) * self.window_singletrange
-            self.atoms._calc.set_singlets({"c1_0":newsinglet})
+            self.bring_system_into_window()
             self.is_first = True
             #Now we are in the middle of the current window, start MC
             current_step = 0
+            now = time.time()
             while (current_step < nsteps):
                 current_step += 1
+                if ( time.time()-now > output_every ):
+                    self.log( "Running MC step {} of {} in window {}".format(current_step,nsteps,self.current_window))
+                    now = time.time()
+
                 # Run MC step
                 self._mc_step()
-                # Get singlet value
-                singlet = self.averager.singlets[0]
-                # Subtract so that singlet value is relative to start of window
-                relative_singlet = singlet - self.min_singlet - (self.current_window * self.window_singletrange) 
-                # First set bin_index to beginning of the correct window
-                bin_index = self.current_window * (self.n_bins) + self.current_window
-                # Now find correct bin_index from the relative singlet
-                bin_index += relative_singlet // self.bin_singletrange
-                # Now update the correct bin
-                self.data[int(bin_index)] = self.data[int(bin_index)] + 1
-                self.energydata[int(bin_index)] = self.energydata[int(bin_index)] + self.current_energy
-                #Reset averager to be able to read singlets in accept function
+                self.update_records()
                 self.averager.reset()
-            #view(self.atoms)
+            self.log( "Acceptance rate in window {}: {}".format(self.current_window,float(self.num_accepted)/self.current_step) )
+            self.reset()
+        self.get_merged_records()
 
-        # Get average energies
-        for m in range(len(self.energydata)):
-            if (self.energydata[m] > 0):
-                self.energydata[m] = self.energydata[m] / (self.data[m] - 1)
-        # Take logarithm of all data entrys
-        for l in range(len(self.data)):
-            self.data[l] = np.log(self.data[l])
-        plt.figure(1)
-        plt.plot(np.array(self.data))
-        # Now the MC has been run for all windows and steps, must edit data for all except first window
-        bin_difference = 0
-        energy_difference = 0
-        # Set range so we do not modify first window of data
-        for j in range(self.n_windows - 1):
-            # Calculate new difference as new window is entered
-            bin_difference = self.data[self.n_bins + j * (self.n_bins + 1)] - self.data[self.n_bins + j * (self.n_bins + 1) - 1]
-            energy_difference = self.energydata[self.n_bins + j * (self.n_bins + 1)] - self.energydata[self.n_bins + j * (self.n_bins + 1) - 1] 
-            for k in range(self.n_bins + 1):
-                # Remove this difference from all bins in the window
-                index = self.n_bins + (j * (self.n_bins + 1)) + k
-                self.data[index] = self.data[index] - bin_difference
-                self.energydata[index] = self.energydata[index] - energy_difference
-        # Now go through data again and remove the bins that are equal
-        for c in range(self.n_windows - 1):
-            del self.data[(c+1) * (self.n_bins)]
-            del self.energydata[(c+1) * (self.n_bins)]
-        plt.figure(2)
-        plt.plot(-np.array(self.data))
-        plt.figure(3)
-        plt.plot(np.array(self.energydata))
-        plt.show()
 
-    def return_umbrella_data( self ):
-        # This function only returns the data
-        return self.data
+    @staticmethod
+    def plot( fname="sgc_data.json" ):
+        """
+        Create some standard plots of the results file produced
+        """
+        with open(fname,'r') as infile:
+            result = json.load(infile)
+        print ("Temperature: {}K".format(result["Temperature"]))
+        print ("Chemical potential: {}K".format(result["chem_pot"]) )
 
-    def return_umbrella_energydata( self ):
-        # This function only returns the energydata
-        return self.energydata
+        figs = []
+        figs.append( plt.figure() )
+        ax = figs[-1].add_subplot(1,1,1)
+        ax.plot( result["xaxis"], result["free_energy"], ls="steps" )
+        ax.set_xlabel( "Singlets" )
+        ax.set_ylabel( "Free energy (eV)" )
+
+        figs.append( plt.figure() )
+        ax = figs[-1].add_subplot(1,1,1)
+        ax.plot( result["xaxis"], result["energy"], ls="steps" )
+        ax.set_xlabel( "Singlets" )
+        ax.set_ylabel( "Energy (eV)" )
+        return figs


### PR DESCRIPTION
Noen endringer har blitt gjort:
1. data var et 1D array, det er når lagret som 2D hvor hvert vindu har et eget 1D array som representerer histogrammet (det samme gjelder energydata). Tror dette er lettere å vedlikeholde dersom man ser på koden om noen måneder.
2. MPI støtte.
3. Splittet en del kode i mindre funksjoner for bedre lesbarhet (åpent for diskusjon selvfølgelig)
4. Skriver ut info om hvor ofte steg aksepteres
![example_barrier](https://user-images.githubusercontent.com/13123407/40306459-132d4476-5cff-11e8-9ed7-794cc6865398.png)
eksempel barriære Al-Mg FCC. De små hakkete linjene skyldes valg av vindu. 100000 MC steg på 4 prosessorer (dvs. 400000 per vindu total). 20 vinduer med 10 bin. Te: 300 K, mu = {"c1_0":-1.069}.

Singlet 0.5 --> Al3Mg, singlet 1.0 --> Al


