### PR TITLE
Remove matplotlib dep

### DIFF
--- a/cemc/ce_calculator.py
+++ b/cemc/ce_calculator.py
@@ -2,20 +2,10 @@ from ase.calculators.calculator import Calculator
 from ase.ce.corrFunc import CorrFunction
 from ase.ce import BulkCrystal
 from ase.ce import BulkSpacegroup
-from ase.build import bulk
-import unittest
-from itertools import product, combinations
 import os
 import numpy as np
-import copy
-import matplotlib as mpl
-mpl.rcParams["svg.fonttype"] = "none"
-from matplotlib import pyplot as plt
-from ase.visualize import view
 from cemc.mcmc import linear_vib_correction as lvc
 from inspect import getargspec
-from cemc.mcmc.util import trans_matrix2listdict
-import gc
 from cemc_cpp_code import PyCEUpdater
 
 from mpi4py import MPI

--- a/cemc/mcmc/fixed_nucleation_size_sampler.py
+++ b/cemc/mcmc/fixed_nucleation_size_sampler.py
@@ -50,7 +50,7 @@ class FixedNucleusMC(Montecarlo):
     @property
     def num_clusters(self):
         self.network.reset()
-        self.network(system_changes)
+        self.network(None)
         stat = self._get_network_statistics()
         self.network.reset()
         return stat["number_of_clusters"]

--- a/cemc/mcmc/mc_observers.py
+++ b/cemc/mcmc/mc_observers.py
@@ -1,14 +1,9 @@
-import matplotlib as mpl
-from matplotlib import pyplot as plt
 import copy
 import numpy as np
 from cemc_cpp_code import PyClusterTracker
 from ase.io.trajectory import TrajectoryWriter
 from cemc.mcmc.averager import Averager
 from cemc.mcmc.util import waste_recycled_average
-
-mpl.rcParams["svg.fonttype"] = "none"
-mpl.rcParams["axes.unicode_minus"] = False
 highlight_elements = ["Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg",
                       "Al", "Si", "P", "S", "Cl", "Ar"]
 

--- a/cemc/mcmc/montecarlo.py
+++ b/cemc/mcmc/montecarlo.py
@@ -8,7 +8,6 @@ import time
 import logging
 from mpi4py import MPI
 from scipy import stats
-from matplotlib import pyplot as plt
 from ase.units import kJ, mol
 from cemc.mcmc import mpi_tools
 from cemc.mcmc.exponential_filter import ExponentialFilter
@@ -401,6 +400,7 @@ class Montecarlo(object):
         self.log("Estimated correlation time: {}".format(tau))
 
         if (self.plot_debug):
+            from matplotlib import pyplot as plt
             gr_spec = {"hspace": 0.0}
             fig, ax = plt.subplots(nrows=2, gridspec_kw=gr_spec, sharex=True)
             x = np.arange(len(self.corrtime_energies))
@@ -578,6 +578,7 @@ class Montecarlo(object):
                              "{}".format(composition))
 
                 if self.plot_debug:
+                    from matplotlib import pyplot as plt
                     fig = plt.figure()
                     ax = fig.add_subplot(1, 1, 1)
                     ax.plot(np.array(all_energies) * mol / kJ)

--- a/cemc/mcmc/multidim_comp_dos.py
+++ b/cemc/mcmc/multidim_comp_dos.py
@@ -1,4 +1,3 @@
-from matplotlib import pyplot as plt
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 
@@ -22,6 +21,7 @@ class CompositionDOS(object):
 
     def plot1D(self):
         """Plot free energy as a function of composition."""
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.plot(self.conc, self.hist, ls="steps")

--- a/cemc/mcmc/sgc_free_energy_barrier.py
+++ b/cemc/mcmc/sgc_free_energy_barrier.py
@@ -8,14 +8,11 @@ import copy
 from scipy import stats
 import mpi_tools
 """
-from ase.units import kB
 from cemc.mcmc import SGCMonteCarlo
 import numpy as np
-from matplotlib import pyplot as plt
 from ase.io import write
 import json
 import time
-from cemc.mcmc.util import get_new_state, waste_recycled_accept_prob
 
 
 class SGCFreeEnergyBarrier(SGCMonteCarlo):
@@ -341,6 +338,7 @@ class SGCFreeEnergyBarrier(SGCMonteCarlo):
 
         :param fname: Filename of the data file
         """
+        from matplotlib import pyplot as plt
         with open(fname, 'r') as infile:
             result = json.load(infile)
         print("Temperature: {}K".format(result["temperature"]))

--- a/cemc/mcmc/transition_path_relaxer.py
+++ b/cemc/mcmc/transition_path_relaxer.py
@@ -2,12 +2,11 @@ from __future__ import print_function
 from cemc.mcmc import SGCNucleation
 import json
 import numpy as np
-from ase.units import kB
 from ase.io.trajectory import TrajectoryWriter
 import copy
-from matplotlib import pyplot as plt
 from ase.calculators.singlepoint import SinglePointCalculator
 import time
+
 
 class TransitionPathRelaxer(object):
     def __init__( self, nuc_mc=None ):
@@ -309,6 +308,7 @@ class TransitionPathRelaxer(object):
         """
         Create a plot to asses convergence of all the paths in the Transition Path Ensemble
         """
+        from matplotlib import pyplot as plt
         with open(path_file,'r') as infile:
             data = json.load(infile)
         try:

--- a/cemc/tools/phase_boundary_tracker.py
+++ b/cemc/tools/phase_boundary_tracker.py
@@ -517,8 +517,15 @@ def predict_composition(
     :param target_temp: Computed composition
     """
     # With this backend one does not need a screen (useful for clusters)
-    from matplotlib import pyplot as plt
-    plt.switch_backend("Agg")
+    has_matplotlib = True
+    try:
+        from matplotlib import pyplot as plt
+        plt.switch_backend("Agg")
+    except ImportError as exc:
+        has_matplotlib = False
+        print(str(exc))
+        print("Waring! Cannot produce convregence plots without matplotlib!")
+
     if len(comp) == 0:
         return target_comp, None
     elif len(comp) <= 2:
@@ -551,9 +558,9 @@ def predict_composition(
     spl = UnivariateSpline(temperatures, comp, k=k, w=weights, s=smoothing)
     predicted_comp = spl(target_temp)
 
-    rgbimage = None
+    rgbimage = np.zeros(1)
     rank = COMM.Get_rank()
-    if rank == 0:
+    if rank == 0 and has_matplotlib:
         # Create a plot of how the spline performs
         fig = plt.figure()
         axis = fig.add_subplot(1, 1, 1)

--- a/cemc/tools/sequence_predicter.py
+++ b/cemc/tools/sequence_predicter.py
@@ -1,5 +1,4 @@
 import numpy as np
-from matplotlib import pyplot as plt
 import warnings
 warnings.simplefilter("ignore",np.RankWarning)
 
@@ -11,6 +10,7 @@ class SequencePredicter(object):
         """
         Visualize the result of the prediction
         """
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         xfit = np.linspace(x[0],x[-1],100)

--- a/cemc/tools/strain_energy.py
+++ b/cemc/tools/strain_energy.py
@@ -4,8 +4,6 @@ from cemc_cpp_code import PyEshelbyTensor, PyEshelbySphere
 from cemc.tools import rot_matrix, rotate_tensor, to_voigt, to_full_tensor
 from itertools import product
 from scipy.optimize import minimize
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib import pyplot as plt
 
 
 class StrainEnergy(object):
@@ -202,6 +200,7 @@ class StrainEnergy(object):
 
     def plot_explore_result(self, explore_result, latex=False):
         """Plot a diagonistic plot over the exploration result."""
+        from matplotlib import pyplot as plt
         energies = []
         x_val = []
         for res in explore_result:
@@ -230,7 +229,7 @@ class StrainEnergy(object):
 
     def plot(self, scale_factor, elast_matrix, rot_seq=None, latex=False):
         """Create a plot of the energy as different aspect ratios."""
-
+        from matplotlib import pyplot as plt
         a_over_c = np.logspace(0, 3, 100)
         b_over_c = [1, 2, 5, 10, 50, 100]
 
@@ -284,6 +283,7 @@ class StrainEnergy(object):
 
     def show_ellipsoid(self, ellipsoid, rot_seq):
         """Show the ellipsoid at given orientation."""
+        from matplotlib import pyplot as plt
         matrix = rot_matrix(rot_seq)
         coefs = np.array(ellipsoid["aspect"])
 

--- a/cemc/wanglandau/histogram.py
+++ b/cemc/wanglandau/histogram.py
@@ -3,7 +3,7 @@ from scipy import interpolate
 from cemc.wanglandau.wltools import convert_array, adapt_array
 import sqlite3 as sq
 import time
-from matplotlib import pyplot as plt
+
 
 class Histogram( object ):
     """
@@ -216,6 +216,7 @@ class Histogram( object ):
         """
         Plots the histogram, DOS and growth variance
         """
+        from matplotlib import pyplot as plt
         E = np.linspace( self.Emin, self.Emax, self.Nbins )
         fig_hist = plt.figure()
         ax_hist = fig_hist.add_subplot(1,1,1)

--- a/cemc/wanglandau/sa_sgc.py
+++ b/cemc/wanglandau/sa_sgc.py
@@ -3,9 +3,7 @@ import ase.units
 from ase.db import connect
 from cemc import CE
 import time
-import matplotlib as mpl
-mpl.rcParams["svg.fonttype"] = "none"
-from matplotlib import pyplot as plt
+
 
 class SimmualtedAnnealingSGC( object ):
     def __init__( self, atoms, db_name, chem_pot=None ):
@@ -115,6 +113,7 @@ class SimmualtedAnnealingSGC( object ):
         Creates a histogram over the number of times each atom have been
         visited
         """
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         ax.plot( self.visiting_statistics, ls="steps" )
@@ -126,6 +125,7 @@ class SimmualtedAnnealingSGC( object ):
         """
         Plots how the composition changes during the simmulated annealing
         """
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         for key in self.comps.keys():

--- a/cemc/wanglandau/sgc_to_cannonical.py
+++ b/cemc/wanglandau/sgc_to_cannonical.py
@@ -2,7 +2,6 @@ from scipy.stats import linregress
 from scipy import interpolate
 import numpy as np
 from scipy.misc import derivative
-from matplotlib import pyplot as plt
 
 class SGCToCanonicalConverter(object):
     def __init__( self, wl_analyzers, natoms ):
@@ -128,6 +127,7 @@ class SGCToCanonicalConverter(object):
         """
         Plots a binary phase diagram
         """
+        from matplotlib import pyplot as plt
         helm_holtz_energies = {}
         comps = []
         free_energies = []

--- a/cemc/wanglandau/wang_landau_db_manager.py
+++ b/cemc/wanglandau/wang_landau_db_manager.py
@@ -1,17 +1,11 @@
-import sys
 import sqlite3 as sq
 import numpy as np
 from cemc.wanglandau.wl_analyzer import WangLandauSGCAnalyzer
 from cemc.wanglandau import wltools
 from ase.db import connect
 import ase.units
-from scipy import special
-import matplotlib as mpl
-mpl.rcParams["axes.unicode_minus"] = False
-mpl.rcParams["font.size"] = 18
-mpl.rcParams["svg.fonttype"] = "none"
-from matplotlib import pyplot as plt
 import copy
+
 
 class WangLandauDBManager( object ):
     def __init__( self, db_name ):

--- a/cemc/wanglandau/wang_landau_sampler.py
+++ b/cemc/wanglandau/wang_landau_sampler.py
@@ -2,7 +2,6 @@
 import numpy as np
 import pickle as pkl
 import ase.units as units
-from matplotlib import pyplot as plt
 from scipy import interpolate
 import copy
 import json
@@ -18,7 +17,6 @@ from cemc.wanglandau.settings import SimulationState
 import logging
 import time
 from cemc.wanglandau.histogram import Histogram
-from matplotlib import pyplot as plt
 from ase import units
 from cemc import CE
 try:
@@ -496,6 +494,7 @@ class WangLandau( object ):
         self.logger.info( "Simulation ended with a modification factor of {}".format(self.f) )
 
     def plot_dos( self ):
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         ax.plot( self.E, self.dos, ls="steps" )
@@ -505,6 +504,7 @@ class WangLandau( object ):
         return fig
 
     def plot_histogram( self ):
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         ax.plot( self.E, self.histogram, ls="steps" )
@@ -516,6 +516,7 @@ class WangLandau( object ):
         """
         Creates a plot of the growth fluctuation
         """
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         ax.plot( self.E, self.get_growth_fluctuation(), ls="steps" )

--- a/cemc/wanglandau/wl_analyzer.py
+++ b/cemc/wanglandau/wl_analyzer.py
@@ -1,6 +1,5 @@
 from ase import units
 import numpy as np
-from matplotlib import pyplot as plt
 from scipy.stats import linregress
 from cemc.wanglandau.wltools import get_formula
 from scipy.stats import linregress
@@ -105,6 +104,7 @@ class WangLandauSGCAnalyzer( object ):
         """
         Plots the density of states
         """
+        from matplotlib import pyplot as plt
         x = 1000.0*self.E/self.n_atoms
         if ( fig is None ):
             fig = plt.figure()
@@ -214,6 +214,7 @@ class WangLandauSGCAnalyzer( object ):
         Gives an estimate plot on how much each bin contributes to the partition
         function for each contribution
         """
+        from matplotlib import pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         low = None

--- a/examples_depr/fluctuation_scaling.py
+++ b/examples_depr/fluctuation_scaling.py
@@ -1,16 +1,12 @@
 import numpy as np
 from scipy.stats import linregress
-import matplotlib as mpl
-mpl.rcParams["axes.unicode_minus"] = False
-mpl.rcParams["svg.fonttype"] = "none"
-mpl.rcParams["font.size"] = 18
-from matplotlib import pyplot as plt
 
 lnf = [1.3550,0.6775,0.3387,0.1693,0.0846,0.04930001,0.02110001,0.00529296875,0.002646484375,0.0013232421875,0.00066162109375,0.000330810546875,0.000165405273437,
 8.27026367187e-05,4.13513183594e-05,2.06756591797e-05]
 N = 10
 
 def var_scaling():
+    from matplotlib import pyplot as plt
     base_name = "data/HistFluct/histogram"
 
     flucts = []
@@ -34,6 +30,7 @@ def var_scaling():
     plt.show()
 
 def plot_ex_hist():
+    from matplotlib import pyplot as plt
     data = np.loadtxt( "data/examplehist.txt" )
     fig = plt.figure()
     x = np.arange(len(data))
@@ -50,6 +47,7 @@ def plot_ex_hist():
     plt.show()
 
 def conv_time_scaling():
+    from matplotlib import pyplot as plt
     lnf = [2.71,1.3550,0.6775,0.3387,0.1693,0.0846,0.04930001,0.02110001,0.0105859,0.00529296875,0.002646484375,0.0013232421875,0.00066162109375,0.000330810546875,0.000165405273437,
     8.27026367187e-05,4.13513183594e-05,2.06756591797e-05,1.03378e-05]
     fname = "data/convergence_times.csv"
@@ -91,6 +89,7 @@ def corr_plot( data ):
     """
     Create a figure of the correlation
     """
+    from matplotlib import pyplot as plt
     shifted = np.roll(data,1,axis=1)
     data = data[:,1:]
     shifted = shifted[:,1:]

--- a/examples_depr/plot_order_params.py
+++ b/examples_depr/plot_order_params.py
@@ -1,12 +1,8 @@
 import numpy as np
-import matplotlib as mpl
-mpl.rcParams["svg.fonttype"] = "none"
-mpl.rcParams["font.size"] = 18
-mpl.rcParams["axes.unicode_minus"] = False
-from matplotlib import pyplot as plt
 import json
 
 def main():
+    from matplotlib import pyplot as plt
     fname = "data/pair_corrfuncs_tempdependent_gsAl7200Mg800.json"
     with open(fname,'r') as infile:
         data = json.load(infile)

--- a/examples_depr/test_al_mg.py
+++ b/examples_depr/test_al_mg.py
@@ -4,7 +4,6 @@ from ase.build import bulk
 from ase.ce.settings import BulkCrystal
 from wanglandau.sa_sgc import SimmualtedAnnealingSGC
 from ase.visualize import view
-from matplotlib import pyplot as plt
 from mcmc import montecarlo as mc
 from mcmc import mc_observers as mc_obs
 from ase.units import kB
@@ -161,7 +160,6 @@ def main( run ):
         gs_finder.show_visit_stat()
         gs_finder.show_compositions()
     view( ceBulk.atoms )
-    #plt.show()
 
 if __name__ == "__main__":
     #run = sys.argv[1] # Run is WL or MC

--- a/tests/test_all_examples.py
+++ b/tests/test_all_examples.py
@@ -4,6 +4,10 @@ import os
 import sys
 try:
     from ase.ce import BulkCrystal
+
+    # Import matplotlib as the examples should only be run if matplotlib
+    # is present
+    from matplotlib import pyplot as plt
     has_CE = True
 except Exception as exc:
     print (exc)

--- a/tests/test_ensure_no_matplotlib.py
+++ b/tests/test_ensure_no_matplotlib.py
@@ -1,0 +1,35 @@
+import unittest
+import sys
+
+try:
+    from cemc import *
+    from cemc.mcmc import *
+    from cemc.tools import *
+    from cemc.wanglandau import *
+    import_msg = ""
+    available = True
+except ImportError as exc:
+    import_msg = str(exc)
+    available = False
+
+
+class TestNoMatplotlib(unittest.TestCase):
+    def _imported(self, mods, name):
+        for m in mods:
+            if m.find(name) != -1:
+                return True
+        return False
+
+    def test_no_matplotlib(self):
+        if not available:
+            self.skipTest(import_msg)
+
+        not_allowed_modules = ["matplotlib", "pyplot", "tkinter", "Tkinter"]
+        import_mod = list(sys.modules.keys())
+        for mod in not_allowed_modules:
+            self.assertFalse(self._imported(import_mod, mod))
+
+
+if __name__ == "__main__":
+    from cemc import TimeLoggingTestRunner
+    unittest.main(testRunner=TimeLoggingTestRunner)


### PR DESCRIPTION
Removed explicit dependency on matplotlib. All MC related code can be run without matplotlib. However, if the user calls a function that produces a plot (most of these have plot in the function name) matplotlib is of course required.