### PR TITLE
Remove angstrom symbol from legend

### DIFF
--- a/cemc/tools/strain_energy.py
+++ b/cemc/tools/strain_energy.py
@@ -227,7 +227,7 @@ class StrainEnergy(object):
                        extent=[theta_min, theta_max, phi_min, phi_max],
                        aspect="auto", origin="lower")
         cb = fig.colorbar(im)
-        cb.set_label("Strain energy (meV/$Å^3$)")
+        cb.set_label("Strain energy (meV per angstrom cubed)")
         ax.set_xlabel("Polar angle (deg)")
         ax.set_ylabel("Azimuthal angle (deg)")
         return fig


### PR DESCRIPTION
Fix:
```
SyntaxError: Non-ASCII character '\xc3' in file /autofs/dcompu/nfshome/jchang/CEMC/cemc/tools/strain_energy.py on line 230, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for detailsSyntaxError: Non-ASCII character '\xc3' in file /autofs/dcompu/nfshome/jchang/CEMC/cemc/tools/strain_energy.py on line 230, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```
by removing angstrom symbol