### PR TITLE
Optimize cpp

### DIFF
--- a/cpp/include/additional_tools.hpp
+++ b/cpp/include/additional_tools.hpp
@@ -46,6 +46,8 @@ std::string py2string(PyObject *str);
 PyObject* int2py(int integer);
 int py2int(PyObject *integer);
 
+PyObject *get_attr(PyObject *obj, const char* name);
+
 SymbolChange& py_tuple_to_symbol_change( PyObject *single_change, SymbolChange &symb_change );
 void py_changes2symb_changes( PyObject* all_changes, std::vector<SymbolChange> &symb_changes );
 void py_change2swap_move(PyObject *all_changes, swap_move &symb_changes);

--- a/cpp/include/additional_tools.hpp
+++ b/cpp/include/additional_tools.hpp
@@ -48,6 +48,9 @@ int py2int(PyObject *integer);
 
 PyObject *get_attr(PyObject *obj, const char* name);
 
+/** Return the length of a python list */
+unsigned int list_size(PyObject *list);
+
 SymbolChange& py_tuple_to_symbol_change( PyObject *single_change, SymbolChange &symb_change );
 void py_changes2symb_changes( PyObject* all_changes, std::vector<SymbolChange> &symb_changes );
 void py_change2swap_move(PyObject *all_changes, swap_move &symb_changes);

--- a/cpp/include/additional_tools.hpp
+++ b/cpp/include/additional_tools.hpp
@@ -54,5 +54,8 @@ void py_change2swap_move(PyObject *all_changes, swap_move &symb_changes);
 template<class T>
 bool is_in_vector(const T &value, const std::vector<T> &vec);
 
+template<class T>
+void insert_in_set(const std::vector<T> &vec, std::set<T> &unique);
+
 #include "additional_tools.tpp"
 #endif

--- a/cpp/include/additional_tools.tpp
+++ b/cpp/include/additional_tools.tpp
@@ -81,3 +81,10 @@ bool is_in_vector(const T& value, const std::vector<T> &vector){
   }
   return false;
 }
+
+template<class T>
+void insert_in_set(const std::vector<T> &vec, std::set<T> &unique){
+  for (const T& elem : vec){
+    unique.insert(elem);
+  }
+}

--- a/cpp/include/basis_function.hpp
+++ b/cpp/include/basis_function.hpp
@@ -12,6 +12,8 @@ class BasisFunction
 {
 public:
     BasisFunction(const bf_raw_t &raw_bfs, const Symbols &symb_with_num);
+    BasisFunction(const BasisFunction &other);
+    BasisFunction& operator=(const BasisFunction &other);
     ~BasisFunction();
 
     /** Return the basis function value for a given decoration number and symbol ID */
@@ -31,6 +33,7 @@ private:
 
     /** Return the corresponding index into the flattened array */
     unsigned int get_index(unsigned int dec_num, unsigned int symb_id) const;
+    void swap(const BasisFunction &other);
 };
 
 #endif

--- a/cpp/include/basis_function.hpp
+++ b/cpp/include/basis_function.hpp
@@ -23,8 +23,8 @@ public:
     /** Stream operator */
     friend std::ostream& operator<<(std::ostream &out, const BasisFunction &bf);
 private:
-    const Symbols *symb_ptr{nullptr};
     bf_raw_t raw_bf_data;
+    const Symbols *symb_ptr{nullptr};
     double *bfs{nullptr};
     unsigned int num_bfs{0};
     unsigned int num_bf_values{0};

--- a/cpp/include/basis_function.hpp
+++ b/cpp/include/basis_function.hpp
@@ -3,6 +3,7 @@
 #include "symbols_with_numbers.hpp"
 #include <map>
 #include <vector>
+#include <iostream>
 
 typedef std::map<std::string, double> dict_dbl_t;
 typedef std::vector<dict_dbl_t> bf_raw_t;
@@ -15,6 +16,12 @@ public:
 
     /** Return the basis function value for a given decoration number and symbol ID */
     double get(unsigned int dec_num, unsigned int symb_id) const;
+
+    /** Return the size (number of basis functions) */
+    unsigned int size() const {return num_bfs;};
+
+    /** Stream operator */
+    friend std::ostream& operator<<(std::ostream &out, const BasisFunction &bf);
 private:
     const Symbols *symb_ptr{nullptr};
     bf_raw_t raw_bf_data;

--- a/cpp/include/basis_function.hpp
+++ b/cpp/include/basis_function.hpp
@@ -1,0 +1,29 @@
+#ifndef BASIS_FUNCTION_H
+#define BASIS_FUNCTION_H
+#include "symbols_with_numbers.hpp"
+#include <map>
+#include <vector>
+
+typedef std::map<std::string, double> dict_dbl_t;
+typedef std::vector<dict_dbl_t> bf_raw_t;
+
+class BasisFunction
+{
+public:
+    BasisFunction(const bf_raw_t &raw_bfs, const Symbols &symb_with_num);
+    ~BasisFunction();
+
+    /** Return the basis function value for a given decoration number and symbol ID */
+    double get(unsigned int dec_num, unsigned int symb_id) const;
+private:
+    const Symbols *symb_ptr{nullptr};
+    bf_raw_t raw_bf_data;
+    double *bfs{nullptr};
+    unsigned int num_bfs{0};
+    unsigned int num_bf_values{0};
+
+    /** Return the corresponding index into the flattened array */
+    unsigned int get_index(unsigned int dec_num, unsigned int symb_id) const;
+};
+
+#endif

--- a/cpp/include/ce_updater.hpp
+++ b/cpp/include/ce_updater.hpp
@@ -77,7 +77,7 @@ public:
   void update_cf( SymbolChange &single_change );
 
   /** Computes the spin product for one element */
-  double spin_product_one_atom( unsigned int ref_indx, const Cluster &indx_list, const std::vector<int> &dec, unsigned int ref_id);
+  double spin_product_one_atom(int ref_indx, const Cluster &indx_list, const std::vector<int> &dec, int ref_id);
 
   /**
   Calculates the new energy given a set of system changes

--- a/cpp/include/ce_updater.hpp
+++ b/cpp/include/ce_updater.hpp
@@ -199,6 +199,7 @@ private:
   bool is_swap_move(const swap_move &move) const;
 
   /** Sort indices according to order */
-  static void sort_indices(std::vector<int> &indx, const std::vector<int> &order);
+  //static void sort_indices(std::vector<int> &indx, const std::vector<int> &order);
+  static void sort_indices(int indices[], const std::vector<int> &order, unsigned int n_indices);
 };
 #endif

--- a/cpp/include/ce_updater.hpp
+++ b/cpp/include/ce_updater.hpp
@@ -15,6 +15,7 @@
 #include "cluster.hpp"
 #include "named_array.hpp"
 #include "symbols_with_numbers.hpp"
+#include "basis_function.hpp"
 
 // Read values from name_list
 // name_list[symm_group][cluster_size] = vector of string variables of all the cluster names
@@ -76,7 +77,7 @@ public:
   void update_cf( SymbolChange &single_change );
 
   /** Computes the spin product for one element */
-  double spin_product_one_atom( unsigned int ref_indx, const Cluster &indx_list, const std::vector<int> &dec, const std::string &ref_symb );
+  double spin_product_one_atom( unsigned int ref_indx, const Cluster &indx_list, const std::vector<int> &dec, unsigned int ref_id);
 
   /**
   Calculates the new energy given a set of system changes
@@ -153,7 +154,8 @@ private:
   std::vector<int> trans_symm_group;
   std::vector<int> trans_symm_group_count;
   std::map<std::string,int> cluster_symm_group_count;
-  bf_list basis_functions;
+  //bf_list basis_functions;
+  BasisFunction *basis_functions{nullptr};
 
   Status_t status{Status_t::NOT_INITIALIZED};
   //Matrix<int> trans_matrix;

--- a/cpp/include/ce_updater.hpp
+++ b/cpp/include/ce_updater.hpp
@@ -14,6 +14,7 @@
 #include "linear_vib_correction.hpp"
 #include "cluster.hpp"
 #include "named_array.hpp"
+#include "symbols_with_numbers.hpp"
 
 // Read values from name_list
 // name_list[symm_group][cluster_size] = vector of string variables of all the cluster names
@@ -106,7 +107,7 @@ public:
   const CFHistoryTracker& get_history() const{ return *history; };
 
   /** Read-only reference to the symbols */
-  const std::vector<std::string>& get_symbols() const { return symbols; };
+  const std::vector<std::string>& get_symbols() const { return symbols_with_id->get_symbols(); };
 
   /** Returns the cluster members */
   const std::vector<cluster_dict>& get_clusters() const {return clusters;};
@@ -146,7 +147,8 @@ private:
   /** Returns the maximum index occuring in the cluster indices */
   unsigned int get_max_indx_of_zero_site() const;
 
-  std::vector<std::string> symbols;
+  //std::vector<std::string> symbols;
+  Symbols *symbols_with_id{nullptr};
   std::vector<cluster_dict> clusters;
   std::vector<int> trans_symm_group;
   std::vector<int> trans_symm_group_count;

--- a/cpp/include/ce_updater.hpp
+++ b/cpp/include/ce_updater.hpp
@@ -24,6 +24,8 @@ typedef std::vector< std::vector< std::vector<std::string> > > name_list;
 typedef std::vector< std::vector< std::vector< std::vector<std::vector<int> > > > > cluster_list;
 typedef std::vector< std::map<std::string,double> > bf_list;
 typedef std::array<SymbolChange,2> swap_move;
+typedef std::unordered_map<std::string, Cluster> cluster_dict;
+
 //typedef std::unordered_map<std::string,double> cf;
 typedef NamedArray cf;
 
@@ -107,7 +109,7 @@ public:
   const std::vector<std::string>& get_symbols() const { return symbols; };
 
   /** Returns the cluster members */
-  const std::vector< std::map<std::string,Cluster> >& get_clusters() const {return clusters;};
+  const std::vector<cluster_dict>& get_clusters() const {return clusters;};
 
   /** Return the cluster with the given name
   * The key in the map is the symmetry group
@@ -145,7 +147,7 @@ private:
   unsigned int get_max_indx_of_zero_site() const;
 
   std::vector<std::string> symbols;
-  std::vector< std::map<std::string, Cluster> > clusters;
+  std::vector<cluster_dict> clusters;
   std::vector<int> trans_symm_group;
   std::vector<int> trans_symm_group_count;
   std::map<std::string,int> cluster_symm_group_count;

--- a/cpp/include/cluster.hpp
+++ b/cpp/include/cluster.hpp
@@ -14,7 +14,7 @@ typedef std::map<std::string, equiv_deco_t > all_equiv_deco_t;
 class Cluster
 {
 public:
-  Cluster():size(0),name("noname"){};
+  Cluster():size(0), name("noname"){};
   Cluster(PyObject *info_dict);
 
   /** Returns the built in list */
@@ -30,8 +30,8 @@ public:
   void construct_equivalent_deco(int n_basis_funcs);
 
   /** Public attributes */
-  std::string name;
   int size;
+  std::string name;
   unsigned int ref_indx;
   unsigned int symm_group;
   double max_cluster_dia;

--- a/cpp/include/cluster_tracker.hpp
+++ b/cpp/include/cluster_tracker.hpp
@@ -65,9 +65,9 @@ public:
   /** Compute the surface of the clusters and return the result in a Python dict */
   PyObject* surface_python() const;
 private:
+  CEUpdater *updater; // Do not own this
   vecstr elements;
   vecstr cnames;
-  CEUpdater *updater; // Do not own this
   std::vector<int> atomic_clusters;
   std::set<int> indices_in_cluster;
   std::set<int> solute_atoms_indices;

--- a/cpp/include/cluster_tracker.hpp
+++ b/cpp/include/cluster_tracker.hpp
@@ -66,8 +66,8 @@ public:
   PyObject* surface_python() const;
 private:
   CEUpdater *updater; // Do not own this
-  vecstr elements;
   vecstr cnames;
+  vecstr elements;
   std::vector<int> atomic_clusters;
   std::set<int> indices_in_cluster;
   std::set<int> solute_atoms_indices;

--- a/cpp/include/row_sparse_struct_matrix.hpp
+++ b/cpp/include/row_sparse_struct_matrix.hpp
@@ -39,7 +39,7 @@ public:
   void insert( unsigned int row, unsigned int col, int value );
 
   /** Check if the provided value is allowed */
-  bool is_allowed_lut( unsigned int col ) const;
+  bool is_allowed_lut(int col) const;
 
   /** Matrix-like access operator. NOTE: For max performance this function does not perform any validity checks */
   const int& operator()( unsigned int row, unsigned int col ) const;

--- a/cpp/include/row_sparse_struct_matrix.hpp
+++ b/cpp/include/row_sparse_struct_matrix.hpp
@@ -26,6 +26,8 @@ class RowSparseStructMatrix
 {
 public:
   RowSparseStructMatrix(){};
+  RowSparseStructMatrix(const RowSparseStructMatrix &other);
+  RowSparseStructMatrix& operator=(const RowSparseStructMatrix &other);
   ~RowSparseStructMatrix(){deallocate();};
 
   /** Initialize the size arrays */
@@ -59,5 +61,6 @@ private:
   bool lut_values_set{false};
   void invalid_col_msg( unsigned int col_provided, std::string& msg ) const;
   void deallocate();
+  void swap(const RowSparseStructMatrix &other);
 };
 #endif

--- a/cpp/include/row_sparse_struct_matrix.hpp
+++ b/cpp/include/row_sparse_struct_matrix.hpp
@@ -26,6 +26,7 @@ class RowSparseStructMatrix
 {
 public:
   RowSparseStructMatrix(){};
+  ~RowSparseStructMatrix(){deallocate();};
 
   /** Initialize the size arrays */
   void set_size( unsigned int n_rows, unsigned int n_non_zero_per_row, unsigned int max_lut_value );
@@ -49,9 +50,14 @@ public:
   /** Access function that verifies that the lookup is valid */
   int get_with_validity_check( unsigned int row, unsigned int col ) const;
 private:
-  std::vector<int> allowed_lookup_values;
-  std::vector<int> lookup;
-  std::vector< std::vector<int> > values;
+  int *allowed_lookup_values{nullptr};
+  int *lookup{nullptr};
+  int **values{nullptr};
+  unsigned int num_rows{0};
+  unsigned int max_lookup_value{0};
+  unsigned int num_non_zero{0};
+  bool lut_values_set{false};
   void invalid_col_msg( unsigned int col_provided, std::string& msg ) const;
+  void deallocate();
 };
 #endif

--- a/cpp/include/symbols_with_numbers.hpp
+++ b/cpp/include/symbols_with_numbers.hpp
@@ -23,6 +23,9 @@ public:
 
     /** Get the array of symbols */
     const vec_str_t& get_symbols() const {return symbols;};
+
+    /** Return the size of the symbol container */
+    unsigned int size() const {return symbols.size();};
 private:
     unsigned int *symb_ids{nullptr};
     vec_str_t symbols;

--- a/cpp/include/symbols_with_numbers.hpp
+++ b/cpp/include/symbols_with_numbers.hpp
@@ -1,0 +1,31 @@
+#ifndef SYMBOLS_H
+#define SYMBOLS_H
+#include <vector>
+#include <string>
+#include <map>
+
+typedef std::vector<std::string> vec_str_t;
+typedef std::map<std::string, unsigned int> dict_uint_t;
+class Symbols
+{
+public:
+    Symbols(const vec_str_t &symbs, const vec_str_t &unique_symbs);
+    ~Symbols();
+
+    /** Return the symbol ID of the atom at site indx */
+    unsigned int id(unsigned int indx) const {return symb_ids[indx];};
+
+    /** Check if the symb_id and symbols are consistent */
+    bool is_consistent() const;
+
+    /** Set a new symbol */
+    void set_symbol(unsigned int indx, const std::string &symb);
+
+    /** Get the array of symbols */
+    const vec_str_t& get_symbols() const {return symbols;};
+private:
+    unsigned int *symb_ids{nullptr};
+    vec_str_t symbols;
+    dict_uint_t symb_id_translation;
+};
+#endif

--- a/cpp/include/symbols_with_numbers.hpp
+++ b/cpp/include/symbols_with_numbers.hpp
@@ -3,13 +3,17 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <set>
 
 typedef std::vector<std::string> vec_str_t;
+typedef std::set<std::string> set_str_t;
 typedef std::map<std::string, unsigned int> dict_uint_t;
 class Symbols
 {
 public:
-    Symbols(const vec_str_t &symbs, const vec_str_t &unique_symbs);
+    Symbols(const vec_str_t &symbs, const set_str_t &unique_symbs);
+    Symbols(const Symbols &other);
+    Symbols& operator =(const Symbols &other);
     ~Symbols();
 
     /** Return the symbol ID of the atom at site indx */
@@ -21,14 +25,26 @@ public:
     /** Set a new symbol */
     void set_symbol(unsigned int indx, const std::string &symb);
 
+    /** Get symbol at position n*/
+    const std::string& get_symbol(unsigned int n) const {return symbols[n];};
+
     /** Get the array of symbols */
     const vec_str_t& get_symbols() const {return symbols;};
 
     /** Return the size of the symbol container */
     unsigned int size() const {return symbols.size();};
+
+    /** Re-initialize all symbols */
+    void set_symbols(const vec_str_t& new_symbs);
 private:
     unsigned int *symb_ids{nullptr};
     vec_str_t symbols;
     dict_uint_t symb_id_translation;
+
+    /** Syncronize the IDs with the symbols vector */
+    void update_ids();
+
+    /** Transfer members to other class */
+    void swap(Symbols &other) const;
 };
 #endif

--- a/cpp/include/symbols_with_numbers.hpp
+++ b/cpp/include/symbols_with_numbers.hpp
@@ -36,6 +36,12 @@ public:
 
     /** Re-initialize all symbols */
     void set_symbols(const vec_str_t& new_symbs);
+
+    /** Get the ID of a particular symbol */
+    unsigned int get_symbol_id(const std::string &symb) const{return symb_id_translation.at(symb);};
+
+    /** Return the number of uniquee symbols */
+    unsigned int num_unique_symbols() const{return symb_id_translation.size();};
 private:
     unsigned int *symb_ids{nullptr};
     vec_str_t symbols;

--- a/cpp/include/wang_landau_sampler.hpp
+++ b/cpp/include/wang_landau_sampler.hpp
@@ -72,9 +72,6 @@ public:
   /** Save convergence time */
   void save_convergence_time( const std::string &fname ) const;
 private:
-  /** Updates the atom position trackers */
-  void update_atom_position_track( unsigned int uid, std::array<SymbolChange,2> &changes, unsigned int select1, unsigned int select2 );
-
   /** Upates all bins above the current bin */
   void update_all_above();
 

--- a/cpp/src/adaptive_windows.cpp
+++ b/cpp/src/adaptive_windows.cpp
@@ -58,7 +58,6 @@ bool AdaptiveWindowHistogram::is_flat( double criteria )
     }
   }
   bool min_ok = false;
-  bool max_ok = false;
   double mean_dbl = 0.0;
 
   // Identify the largest window from the upper energy range that is locally converged
@@ -82,7 +81,6 @@ bool AdaptiveWindowHistogram::is_flat( double criteria )
 
     mean_dbl = static_cast<double>(mean)/count;
     min_ok =  minimum_ok(mean_dbl,criteria,minimum);
-    max_ok =  maximum_ok(mean_dbl,criteria,maximum);
 
     // Check if the window contains the minimum number of bins to check for local convergence
     if ( (count > minimum_width) || (count >= maximum_possible_number_of_converged_bins) )

--- a/cpp/src/adaptive_windows.cpp
+++ b/cpp/src/adaptive_windows.cpp
@@ -200,7 +200,7 @@ void AdaptiveWindowHistogram::make_dos_continous()
 
 bool AdaptiveWindowHistogram::bin_in_range( int bin ) const
 {
-  return (bin>=0) && (bin<current_upper_bin);
+  return (bin>=0) && (bin<static_cast<int>(current_upper_bin));
 }
 
 void AdaptiveWindowHistogram::clear_updater_states()

--- a/cpp/src/additional_tools.cpp
+++ b/cpp/src/additional_tools.cpp
@@ -73,7 +73,7 @@ SymbolChange& py_tuple_to_symbol_change( PyObject *single_change, SymbolChange &
 
 void py_changes2symb_changes( PyObject* all_changes, vector<SymbolChange> &symb_changes )
 {
-  int size = PyList_Size(all_changes);
+  unsigned int size = list_size(all_changes);
   for (unsigned int i=0;i<size;i++ )
   {
     SymbolChange symb_change;
@@ -84,7 +84,7 @@ void py_changes2symb_changes( PyObject* all_changes, vector<SymbolChange> &symb_
 
 void py_change2swap_move(PyObject* all_changes, swap_move &symb_changes)
 {
-  int size = PyList_Size(all_changes);
+  unsigned int size = list_size(all_changes);
   for (unsigned int i=0;i<size;i++ )
   {
     SymbolChange symb_change;

--- a/cpp/src/additional_tools.cpp
+++ b/cpp/src/additional_tools.cpp
@@ -1,5 +1,7 @@
 #include "additional_tools.hpp"
 #include "cf_history_tracker.hpp"
+#include <stdexcept>
+#include <sstream>
 
 using namespace std;
 
@@ -89,4 +91,16 @@ void py_change2swap_move(PyObject* all_changes, swap_move &symb_changes)
     py_tuple_to_symbol_change( PyList_GetItem(all_changes,i), symb_change );
     symb_changes[i]  = symb_change;
   }
+}
+
+PyObject* get_attr(PyObject* obj, const char* name)
+{
+  PyObject* attr = PyObject_GetAttrString(obj, name);
+  if (attr == nullptr)
+  {
+    stringstream ss;
+    ss << "Python object has not attribute " << name;
+    throw invalid_argument(ss.str());
+  }
+  return attr;
 }

--- a/cpp/src/additional_tools.cpp
+++ b/cpp/src/additional_tools.cpp
@@ -104,3 +104,12 @@ PyObject* get_attr(PyObject* obj, const char* name)
   }
   return attr;
 }
+
+unsigned int list_size(PyObject *list)
+{
+  if (!PyList_Check(list))
+  {
+    throw invalid_argument("Python object is not a list. Cannot retrieve the length!");
+  }
+  return PyList_Size(list);
+}

--- a/cpp/src/basis_function.cpp
+++ b/cpp/src/basis_function.cpp
@@ -1,0 +1,32 @@
+#include "basis_function.hpp"
+
+BasisFunction::BasisFunction(const bf_raw_t &raw_bfs, const Symbols &symb_with_num): \
+    raw_bf_data(raw_bfs), symb_ptr(&symb_with_num)
+    {
+        num_bfs = raw_bf_data.size();
+        num_bf_values = symb_ptr->num_unique_symbols()-1;
+        bfs = new double[num_bfs*num_bf_values];
+
+        // Transfer the raw bf array to the flattened array
+        for (unsigned int dec_num=0;dec_num<num_bfs;dec_num++)
+        for (auto iter=raw_bf_data[dec_num].begin(); iter != raw_bf_data[dec_num].end(); ++iter)
+        {
+            unsigned int indx = get_index(dec_num, symb_ptr->get_symbol_id(iter->first));
+            bfs[indx] = iter->second;
+        }
+    };
+
+BasisFunction::~BasisFunction(){
+    delete [] bfs; bfs = nullptr;
+}
+
+
+unsigned int BasisFunction::get_index(unsigned int dec_num, unsigned int symb_id) const
+{
+    return dec_num*num_bf_values + symb_id;
+}
+
+double BasisFunction::get(unsigned int dec_num, unsigned int symb_id) const
+{
+    return bfs[get_index(dec_num, symb_id)];
+}

--- a/cpp/src/basis_function.cpp
+++ b/cpp/src/basis_function.cpp
@@ -18,10 +18,18 @@ BasisFunction::BasisFunction(const bf_raw_t &raw_bfs, const Symbols &symb_with_n
         }
     };
 
-BasisFunction::~BasisFunction(){
-    delete [] bfs; bfs = nullptr;
+BasisFunction::BasisFunction(const BasisFunction &other){
+    this->swap(other);
 }
 
+BasisFunction& BasisFunction::operator=(const BasisFunction &other){
+    this->swap(other);
+    return *this;
+}
+
+BasisFunction::~BasisFunction(){
+    delete [] bfs;
+}
 
 unsigned int BasisFunction::get_index(unsigned int dec_num, unsigned int symb_id) const
 {
@@ -31,6 +39,17 @@ unsigned int BasisFunction::get_index(unsigned int dec_num, unsigned int symb_id
 double BasisFunction::get(unsigned int dec_num, unsigned int symb_id) const
 {
     return bfs[get_index(dec_num, symb_id)];
+}
+
+void BasisFunction::swap(const BasisFunction &other)
+{
+    this->raw_bf_data = other.raw_bf_data;
+    this->symb_ptr = other.symb_ptr;
+    this->num_bfs = other.num_bfs;
+    this->num_bf_values = other.num_bf_values;
+    if (this->bfs != nullptr) delete [] this->bfs;
+    this->bfs = new double[num_bfs*num_bf_values];
+    memcpy(this->bfs, other.bfs, num_bfs*num_bf_values*sizeof(double));
 }
 
 ostream& operator<<(ostream &out, const BasisFunction &bf)

--- a/cpp/src/basis_function.cpp
+++ b/cpp/src/basis_function.cpp
@@ -1,10 +1,12 @@
 #include "basis_function.hpp"
+#include "additional_tools.hpp"
 
+using namespace std;
 BasisFunction::BasisFunction(const bf_raw_t &raw_bfs, const Symbols &symb_with_num): \
     raw_bf_data(raw_bfs), symb_ptr(&symb_with_num)
     {
         num_bfs = raw_bf_data.size();
-        num_bf_values = symb_ptr->num_unique_symbols()-1;
+        num_bf_values = symb_ptr->num_unique_symbols();
         bfs = new double[num_bfs*num_bf_values];
 
         // Transfer the raw bf array to the flattened array
@@ -29,4 +31,17 @@ unsigned int BasisFunction::get_index(unsigned int dec_num, unsigned int symb_id
 double BasisFunction::get(unsigned int dec_num, unsigned int symb_id) const
 {
     return bfs[get_index(dec_num, symb_id)];
+}
+
+ostream& operator<<(ostream &out, const BasisFunction &bf)
+{
+    out << "Basis Function object\n";
+    out << "Raw data\n";
+    out << bf.raw_bf_data << "\n";
+    out << "Flattened array\n";
+    for (unsigned int i=0;i<bf.num_bfs*bf.num_bf_values;i++)
+    {
+        out << bf.bfs[i] << " ";
+    }
+    return out;
 }

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -52,7 +52,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   {
     PyObject *pyindx = int2py(i);
     PyObject *atom = PyObject_GetItem(atoms, pyindx);
-    PyObject *pysymb = PyObject_GetAttrString(atom, "symbol");
+    PyObject *pysymb = get_attr(atom, "symbol");
 
     if (pysymb == nullptr)
     {
@@ -67,7 +67,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   set<string> unique_symbols;
 
   // Extract unique symbols from settings
-  PyObject *py_unique_symb = PyObject_GetAttrString(BC, "unique_elements");
+  PyObject *py_unique_symb = get_attr(BC, "unique_elements");
   for (unsigned int i=0;i<PyList_Size(py_unique_symb);i++)
   {
     unique_symbols.insert(py2string(PyList_GetItem(py_unique_symb, i)));
@@ -78,7 +78,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   symbols_with_id = new Symbols(symbols, unique_symbols);
 
   // Build read the translational sites
-  PyObject* py_trans_symm_group = PyObject_GetAttrString( BC, "index_by_trans_symm" );
+  PyObject* py_trans_symm_group = get_attr( BC, "index_by_trans_symm" );
 
   if (py_trans_symm_group == nullptr)
   {
@@ -89,7 +89,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
     cerr << "Reading background indices\n";
   #endif
   // Read the backgound indices from settings
-  PyObject *bkg_indx = PyObject_GetAttrString(BC, "background_indices");
+  PyObject *bkg_indx = get_attr(BC, "background_indices");
   read_background_indices(bkg_indx);
   Py_DECREF(bkg_indx);
 
@@ -103,7 +103,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   // Read cluster names
   create_cname_with_dec( corrFunc );
 
-  PyObject *py_num_elements = PyObject_GetAttrString(BC, "num_unique_elements");
+  PyObject *py_num_elements = get_attr(BC, "num_unique_elements");
 
   if (py_num_elements == nullptr)
   {
@@ -112,7 +112,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   int num_bfs = py2int(py_num_elements)-1;
   Py_DECREF(py_num_elements);
 
-  PyObject* cluster_info = PyObject_GetAttrString(BC, "cluster_info");
+  PyObject* cluster_info = get_attr(BC, "cluster_info");
 
   if (cluster_info == nullptr)
   {
@@ -154,7 +154,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
     cerr << "Reading basis functions from BC object\n";
   #endif
 
-  PyObject* bfs = PyObject_GetAttrString( BC, "basis_functions" );
+  PyObject* bfs = get_attr( BC, "basis_functions" );
   if ( bfs == NULL )
   {
     status = Status_t::INIT_FAILED;
@@ -183,7 +183,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   #ifdef CE_DEBUG
     cerr << "Reading translation matrix from BC\n";
   #endif
-  PyObject* trans_mat_orig = PyObject_GetAttrString(BC,"trans_matrix");
+  PyObject* trans_mat_orig = get_attr(BC,"trans_matrix");
   if ( trans_mat_orig == NULL )
   {
     status = Status_t::INIT_FAILED;

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -233,7 +233,7 @@ double CEUpdater::spin_product_one_atom( unsigned int ref_indx, const Cluster &c
   {
     double sp_temp = 1.0;
     unsigned int n_memb = indx_list[i].size();
-    //vector<int> indices(n_memb+1);
+    
     int indices[n_memb+1];
     indices[0] = ref_indx;
     for (unsigned int j=0;j<n_memb;j++)

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -229,10 +229,11 @@ double CEUpdater::spin_product_one_atom( unsigned int ref_indx, const Cluster &c
   const vector< vector<int> >& indx_list = cluster.get();
   const vector< vector<int> >& order = cluster.get_order();
   unsigned int num_indx = indx_list.size();
+  unsigned int n_memb = indx_list[0].size();
+  
   for ( unsigned int i=0;i<num_indx;i++ )
   {
     double sp_temp = 1.0;
-    unsigned int n_memb = indx_list[i].size();
     
     int indices[n_memb+1];
     indices[0] = ref_indx;

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -590,7 +590,7 @@ CEUpdater* CEUpdater::copy() const
   obj->trans_symm_group = trans_symm_group;
   obj->trans_symm_group_count = trans_symm_group_count;
   obj->cluster_symm_group_count = cluster_symm_group_count;
-  obj->basis_functions = basis_functions;
+  obj->basis_functions = new BasisFunction(*basis_functions);
   obj->status = status;
   obj->trans_matrix = trans_matrix;
   obj->ctype_lookup = ctype_lookup;

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -107,7 +107,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   for (unsigned int i=0;i<num_trans_symm;i++)
   {
     PyObject *info_dicts = PyList_GetItem(cluster_info, i);
-    map<string, Cluster> new_clusters;
+    cluster_dict new_clusters;
     Py_ssize_t pos = 0;
     PyObject *key;
     PyObject *value;

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -245,6 +245,10 @@ double CEUpdater::spin_product_one_atom( unsigned int ref_indx, const Cluster &c
       indices[j+1] = trans_matrix(ref_indx, *(indx_list_ptr+j));
     }
     sort_indices(indices, order[i], n_memb+1);
+
+    // TODO: Basis functions is a vector of dictionaries
+    // it hurts performance to lookup values in a map
+    // with string key.
     for ( unsigned int j=0;j<n_memb+1;j++ )
     {
       if (indices[j] == ref_indx)

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -230,16 +230,19 @@ double CEUpdater::spin_product_one_atom( unsigned int ref_indx, const Cluster &c
   const vector< vector<int> >& order = cluster.get_order();
   unsigned int num_indx = indx_list.size();
   unsigned int n_memb = indx_list[0].size();
-  
+
   for ( unsigned int i=0;i<num_indx;i++ )
   {
     double sp_temp = 1.0;
     
     int indices[n_memb+1];
     indices[0] = ref_indx;
+
+    // Use pointer arithmetics in the inner most loop
+    const int *indx_list_ptr = &indx_list[i][0];
     for (unsigned int j=0;j<n_memb;j++)
     {
-      indices[j+1] = trans_matrix(ref_indx, indx_list[i][j]);
+      indices[j+1] = trans_matrix(ref_indx, *(indx_list_ptr+j));
     }
     sort_indices(indices, order[i], n_memb+1);
     for ( unsigned int j=0;j<n_memb+1;j++ )

--- a/cpp/src/ce_updater.cpp
+++ b/cpp/src/ce_updater.cpp
@@ -68,7 +68,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
 
   // Extract unique symbols from settings
   PyObject *py_unique_symb = get_attr(BC, "unique_elements");
-  for (unsigned int i=0;i<PyList_Size(py_unique_symb);i++)
+  for (unsigned int i=0;i<list_size(py_unique_symb);i++)
   {
     unique_symbols.insert(py2string(PyList_GetItem(py_unique_symb, i)));
   }
@@ -118,7 +118,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   {
     throw invalid_argument("cluster_info is nullptr!");
   }
-  unsigned int num_trans_symm = PyList_Size(cluster_info);
+  unsigned int num_trans_symm = list_size(cluster_info);
 
   for (unsigned int i=0;i<num_trans_symm;i++)
   {
@@ -164,7 +164,7 @@ void CEUpdater::init(PyObject *py_atoms, PyObject *BC, PyObject *corrFunc, PyObj
   // Reading basis functions from python object
   PyObject *key;
   PyObject *value;
-  unsigned int n_bfs = PyList_Size(bfs);
+  unsigned int n_bfs = list_size(bfs);
   bf_list basis_func_raw;
   for ( unsigned int i=0;i<n_bfs;i++ )
   {
@@ -301,7 +301,7 @@ SymbolChange& CEUpdater::py_tuple_to_symbol_change( PyObject *single_change, Sym
 
 void CEUpdater::py_changes2_symb_changes( PyObject* all_changes, vector<SymbolChange> &symb_changes )
 {
-  int size = PyList_Size(all_changes);
+  int size = list_size(all_changes);
   for (unsigned int i=0;i<size;i++ )
   {
     SymbolChange symb_change;
@@ -473,7 +473,7 @@ void CEUpdater::undo_changes_tracker(int num_steps)
 double CEUpdater::calculate( PyObject *system_changes )
 {
 
-  int size = PyList_Size(system_changes);
+  int size = list_size(system_changes);
   if ( size == 0 )
   {
     return get_energy();
@@ -739,11 +739,11 @@ void CEUpdater::build_trans_symm_group( PyObject *py_trans_symm_group )
     trans_symm_group[i] = -1;
   }
 
-  int list_size = PyList_Size( py_trans_symm_group );
-  for ( int i=0;i<list_size;i++ )
+  unsigned int py_list_size = list_size(py_trans_symm_group);
+  for ( int i=0;i<py_list_size;i++ )
   {
     PyObject *sublist = PyList_GetItem( py_trans_symm_group, i );
-    int n_sites = PyList_Size( sublist );
+    int n_sites = list_size( sublist );
     for ( unsigned int j=0;j<n_sites;j++ )
     {
       int indx = py2int( PyList_GetItem( sublist, j ) );
@@ -767,7 +767,7 @@ void CEUpdater::build_trans_symm_group( PyObject *py_trans_symm_group )
   }
 
   // Count the number of atoms in each symmetry group
-  trans_symm_group_count.resize(list_size);
+  trans_symm_group_count.resize(py_list_size);
   for ( unsigned int i=0;i<trans_symm_group.size();i++ )
   {
     if (trans_symm_group[i] >= 0){
@@ -915,7 +915,7 @@ void CEUpdater::read_trans_matrix( PyObject* py_trans_mat )
 
   if ( is_list )
   {
-    int size = PyList_Size(py_trans_mat);
+    int size = list_size(py_trans_mat);
     trans_matrix.set_size( size, unique_indx_vec.size(), max_indx );
     trans_matrix.set_lookup_values(unique_indx_vec);
     cout << "Reading translation matrix from list of dictionaries\n";
@@ -1019,7 +1019,7 @@ void CEUpdater::read_background_indices(PyObject *bkg_indices){
   fill(is_background_index.begin(), is_background_index.end(), false);
 
   // Set to true if index is in bkg_indices
-  int size = PyList_Size(bkg_indices);
+  int size = list_size(bkg_indices);
   for (int i=0;i<size;i++){
     PyObject *py_indx = PyList_GetItem(bkg_indices, i);
     int indx = py2int(py_indx);

--- a/cpp/src/cluster.cpp
+++ b/cpp/src/cluster.cpp
@@ -103,7 +103,7 @@ void Cluster::construct_equivalent_deco(int n_basis_funcs)
 
     // Create a nested vector based on the result from Python
     vector< vector<int> > eq_dec;
-    int size = list_size(py_equiv);
+    unsigned int size = list_size(py_equiv);
     for (unsigned int i=0;i<size;i++)
     {
       vector<int> one_dec;
@@ -136,8 +136,8 @@ void Cluster::all_deco(int num_bfs, vector< vector<int> > &deco) const
   }
   else if (get_size() == 2)
   {
-    for (unsigned int i=0;i<num_bfs;i++)
-    for (unsigned int j=0;j<num_bfs;j++)
+    for (int i=0;i<num_bfs;i++)
+    for (int j=0;j<num_bfs;j++)
     {
       vector<int> vec = {i, j};
       deco.push_back(vec);
@@ -145,9 +145,9 @@ void Cluster::all_deco(int num_bfs, vector< vector<int> > &deco) const
   }
   else if (get_size() == 3)
   {
-    for (unsigned int i=0;i<num_bfs;i++)
-    for (unsigned int j=0;j<num_bfs;j++)
-    for (unsigned int k=0;k<num_bfs;k++)
+    for (int i=0;i<num_bfs;i++)
+    for (int j=0;j<num_bfs;j++)
+    for (int k=0;k<num_bfs;k++)
     {
       vector<int> vec = {i, j, k};
       deco.push_back(vec);
@@ -155,10 +155,10 @@ void Cluster::all_deco(int num_bfs, vector< vector<int> > &deco) const
   }
   else if(get_size() == 4)
   {
-    for (unsigned int i=0;i<num_bfs;i++)
-    for (unsigned int j=0;j<num_bfs;j++)
-    for (unsigned int k=0;k<num_bfs;k++)
-    for (unsigned int l=0;l<num_bfs;l++)
+    for (int i=0;i<num_bfs;i++)
+    for (int j=0;j<num_bfs;j++)
+    for (int k=0;k<num_bfs;k++)
+    for (int l=0;l<num_bfs;l++)
     {
       vector<int> vec = {i, j, k, l};
       deco.push_back(vec);

--- a/cpp/src/cluster.cpp
+++ b/cpp/src/cluster.cpp
@@ -103,7 +103,7 @@ void Cluster::construct_equivalent_deco(int n_basis_funcs)
 
     // Create a nested vector based on the result from Python
     vector< vector<int> > eq_dec;
-    int size = PyList_Size(py_equiv);
+    int size = list_size(py_equiv);
     for (unsigned int i=0;i<size;i++)
     {
       vector<int> one_dec;
@@ -233,7 +233,7 @@ void Cluster::parse_info_dict(PyObject *info)
 
 void Cluster::nested_list_to_cluster(PyObject *py_list, cluster_t &vec)
 {
-  int size = PyList_Size(py_list);
+  int size = list_size(py_list);
   for (int i=0;i<size;i++)
   {
     vector<int> one_cluster;

--- a/cpp/src/cluster_tracker.cpp
+++ b/cpp/src/cluster_tracker.cpp
@@ -92,7 +92,7 @@ void ClusterTracker::get_cluster_size( map<int,int> &num_members_in_cluster ) co
 {
   for ( unsigned int i=0;i<atomic_clusters.size();i++ )
   {
-    int r_indx = root_indx(i);
+    unsigned int r_indx = root_indx(i);
 
     if ( r_indx != i )
     {
@@ -153,7 +153,7 @@ PyObject* ClusterTracker::get_cluster_statistics_python() const
   }
 
   PyObject* size_list = PyList_New(0);
-  for ( int i=0; i< cluster_sizes.size();i++ )
+  for (unsigned int i=0; i< cluster_sizes.size();i++ )
   {
     PyObject *value = int2py( cluster_sizes[i] );
     PyList_Append( size_list, value );
@@ -247,7 +247,7 @@ void ClusterTracker::get_members_of_largest_cluster( vector<int> &members )
 {
   unsigned int root_indx_largest = root_indx_largest_cluster();
   members.clear();
-  for ( int id=0;id<atomic_clusters.size();id++ )
+  for (unsigned int id=0;id<atomic_clusters.size();id++ )
   {
     if ( root_indx(id) == root_indx_largest )
     {
@@ -276,7 +276,7 @@ unsigned int ClusterTracker::root_indx( unsigned int indx ) const
 bool ClusterTracker::is_connected(unsigned int indx1, unsigned int indx2) const{
   unsigned int counter = 0;
   unsigned int max_cluster_size = atomic_clusters.size();
-  int root = indx1;
+  unsigned int root = indx1;
   while((atomic_clusters[root] != -1) && (counter<max_cluster_size))
   {
     counter += 1;
@@ -320,7 +320,7 @@ void ClusterTracker::surface( map<int,int> &surf ) const
             continue;
           }
           const vector< vector<int> >& members = clusters[symm_group].at(cname).get();
-          for ( int subgroup=0;subgroup<members.size();subgroup++ )
+          for (unsigned int subgroup=0;subgroup<members.size();subgroup++)
           {
             int indx = trans_mat( i,members[subgroup][0] );
             if (!is_cluster_element(symbs[indx]))
@@ -564,7 +564,7 @@ void ClusterTracker::rebuild_cluster(){
 
     // Find all sites belonging to this cluster
     vector<int> indx_in_group;
-    for (int i=0;i<grp_indx.size();i++){
+    for (unsigned int i=0;i<grp_indx.size();i++){
       if (grp_indx[i] == grp){
         indx_in_group.push_back(i);
       }
@@ -579,7 +579,7 @@ void ClusterTracker::rebuild_cluster(){
 
     atomic_clusters[indx_in_group[0]] = -1;
     already_inserted[indx_in_group[0]] = true;
-    for (int i=0;i<indx_in_group.size();i++){
+    for (unsigned int i=0;i<indx_in_group.size();i++){
       // Attach all neighbours to the current site
       for (auto iter=indices_in_cluster.begin(); iter != indices_in_cluster.end(); ++iter){
         int indx = trans_mat(indx_in_group[i], *iter);
@@ -594,7 +594,7 @@ void ClusterTracker::rebuild_cluster(){
 
 bool ClusterTracker::has_minimal_connectivity() const{
   const auto& trans_mat = updater->get_trans_matrix();
-  for (int i=0;i<atomic_clusters.size();i++){
+  for (unsigned int i=0;i<atomic_clusters.size();i++){
     if (atomic_clusters[i] != -1){
       bool found_neighbor = false;
       for (auto iter=indices_in_cluster.begin(); iter != indices_in_cluster.end(); ++iter){

--- a/cpp/src/cluster_tracker.cpp
+++ b/cpp/src/cluster_tracker.cpp
@@ -203,7 +203,7 @@ PyObject* ClusterTracker::atomic_clusters2group_indx_python() const
 
 void ClusterTracker::verify_cluster_name_exists() const
 {
-  const vector< map<string,Cluster> >& clusters = updater->get_clusters();
+  const vector< cluster_dict>& clusters = updater->get_clusters();
   vector<string> all_names;
   for ( unsigned int i=0;i<clusters.size();i++ )
   {
@@ -295,7 +295,7 @@ bool ClusterTracker::is_connected(unsigned int indx1, unsigned int indx2) const{
 void ClusterTracker::surface( map<int,int> &surf ) const
 {
   const vector<string>& symbs = updater->get_symbols();
-  const vector< map<string,Cluster> >& clusters = updater->get_clusters();
+  const vector< cluster_dict>& clusters = updater->get_clusters();
   const auto& trans_mat = updater->get_trans_matrix();
 
   for ( unsigned int i=0;i<atomic_clusters.size();i++ )
@@ -529,8 +529,8 @@ bool ClusterTracker::detach_neighbours(int ref_indx, bool can_create_new_cluster
 }
 
 void ClusterTracker::init_cluster_indices(){
-  const vector< map<string,Cluster> >& clusters = updater->get_clusters();
-  for ( const map<string,Cluster> &cluster : clusters )
+  const vector< cluster_dict>& clusters = updater->get_clusters();
+  for ( const cluster_dict&cluster : clusters )
   {
     for (const string &cname : cnames )
     {

--- a/cpp/src/eshelby_tensor.cpp
+++ b/cpp/src/eshelby_tensor.cpp
@@ -135,7 +135,6 @@ void EshelbyTensor::I_matrix_oblate_sphere(mat3x3 &result, const vec3 &princ) co
   semi_axes[0] = a*a;
   semi_axes[1] = b*b;
   semi_axes[2] = c*c;
-  double tol = 1E-6;
 
   // First row
   result[0][2] = princ[0] - 4.0*PI/3.0;
@@ -369,7 +368,7 @@ void EshelbyTensor::array_to_key(string &key, int array[4])
 void EshelbyTensor::circular_shift(double data[], int size)
 {
   double first = data[0];
-  for (unsigned int i=0;i<size-1;i++)
+  for (int i=0;i<size-1;i++)
   {
     data[i] = data[i+1];
   }

--- a/cpp/src/histogram.cpp
+++ b/cpp/src/histogram.cpp
@@ -134,9 +134,9 @@ double Histogram::get_dos_ratio_old_divided_by_new( unsigned int old_bin, unsign
   return exp(diff);
 }
 
-bool Histogram::bin_in_range( int bin ) const
+bool Histogram::bin_in_range(int bin) const
 {
-  return (bin >= 0) && ( bin < hist.size() );
+  return (bin >= 0) && (bin < static_cast<int>(hist.size()));
 }
 
 void Histogram::send_to_python_hist( PyObject *py_hist )
@@ -176,7 +176,6 @@ void Histogram::init_from_pyhist( PyObject *py_hist )
   PyObject *py_logdos = PyObject_GetAttrString( py_hist, "logdos" );
   PyObject *py_logdos_npy = PyArray_FROM_OTF( py_logdos, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY );
   PyObject *py_known_struct = PyObject_GetAttrString( py_hist, "known_state" );
-  PyObject *py_known_struct_npy = PyArray_FROM_OTF( py_known_struct, NPY_UINT8, NPY_ARRAY_IN_ARRAY );
   npy_intp *dims = PyArray_DIMS( py_logdos_npy );
   logdos.resize( dims[0] );
   known_structures.resize( dims[0] );

--- a/cpp/src/row_sparse_struct_matrix.cpp
+++ b/cpp/src/row_sparse_struct_matrix.cpp
@@ -27,6 +27,16 @@ void RowSparseStructMatrix::set_size( unsigned int n_rows, unsigned int n_non_ze
   allowed_lookup_values = new int[num_non_zero];
 }
 
+RowSparseStructMatrix::RowSparseStructMatrix(const RowSparseStructMatrix &other)
+{
+  this->swap(other);
+}
+
+RowSparseStructMatrix& RowSparseStructMatrix::operator=(const RowSparseStructMatrix &other){
+  this->swap(other);
+  return *this;
+}
+
 void RowSparseStructMatrix::deallocate()
 {
   delete [] allowed_lookup_values;
@@ -141,4 +151,24 @@ void RowSparseStructMatrix::invalid_col_msg( unsigned int col_provided, string &
       ss << allowed_lookup_values[i] << endl;
   }
   msg = ss.str();
+}
+
+void RowSparseStructMatrix::swap(const RowSparseStructMatrix &other)
+{
+  this->num_rows = other.num_rows;
+  this->max_lookup_value = other.max_lookup_value;
+  this->num_non_zero = other.num_non_zero;
+
+  this->allowed_lookup_values = new int[num_non_zero];
+  this->lookup = new int[num_non_zero];
+  this->values = new int*[num_rows];
+  for (unsigned int i=0;i<num_rows;i++)
+  {
+    this->values[i] = new int[num_non_zero];
+    memcpy(this->values[i], other.values[i], num_non_zero*sizeof(int));
+  }
+
+  // Copy content
+  memcpy(this->allowed_lookup_values, other.allowed_lookup_values, num_non_zero*sizeof(int));
+  memcpy(this->lookup, other.lookup, num_non_zero*sizeof(int));
 }

--- a/cpp/src/row_sparse_struct_matrix.cpp
+++ b/cpp/src/row_sparse_struct_matrix.cpp
@@ -60,7 +60,7 @@ void RowSparseStructMatrix::set_lookup_values( const vector<int> &lut_values )
   
   memcpy(allowed_lookup_values, &lut_values[0], lut_values.size()*sizeof(int));
 
-  int max_value = *max_element(lut_values.begin(), lut_values.end() );
+  unsigned int max_value = *max_element(lut_values.begin(), lut_values.end() );
   if ( max_value > max_lookup_value )
   {
     throw invalid_argument( "The maximum lookup value exceeds the number given when the size was specified!" );
@@ -77,7 +77,7 @@ void RowSparseStructMatrix::set_lookup_values( const vector<int> &lut_values )
   }
 }
 
-bool RowSparseStructMatrix::is_allowed_lut( unsigned int col ) const
+bool RowSparseStructMatrix::is_allowed_lut(int col) const
 {
   for ( unsigned int i=0;i<num_non_zero;i++ )
   {

--- a/cpp/src/symbols_with_numbers.cpp
+++ b/cpp/src/symbols_with_numbers.cpp
@@ -1,0 +1,41 @@
+#include "symbols_with_numbers.hpp"
+
+using namespace std;
+
+Symbols::~Symbols(){
+    delete [] symb_ids;
+    symb_ids = nullptr;
+}
+
+Symbols::Symbols(const vec_str_t &symbs, const vec_str_t &unique_symbs): symbols(symbs){
+    symb_ids = new unsigned int[symbs.size()];
+    unsigned int current_id = 0;
+    for (const string &symb: unique_symbs)
+    {
+        symb_id_translation[symb] = current_id++;
+    }
+
+    // Populate the symb_id array
+    for (unsigned int i=0;i<symbs.size();i++)
+    {
+        symb_ids[i] = symb_id_translation[symbs[i]];
+    }
+}
+
+bool Symbols::is_consistent() const
+{
+    for (unsigned int i=0;i<symbols.size();i++)
+    {
+        if (symb_ids[i] != symb_id_translation.at(symbols[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void Symbols::set_symbol(unsigned int indx, const string &new_symb)
+{
+    symbols[indx] = new_symb;
+    symb_ids[indx] = symb_id_translation[new_symb];
+}

--- a/cpp/src/symbols_with_numbers.cpp
+++ b/cpp/src/symbols_with_numbers.cpp
@@ -1,4 +1,5 @@
 #include "symbols_with_numbers.hpp"
+#include <cstring>
 
 using namespace std;
 
@@ -7,19 +8,26 @@ Symbols::~Symbols(){
     symb_ids = nullptr;
 }
 
-Symbols::Symbols(const vec_str_t &symbs, const vec_str_t &unique_symbs): symbols(symbs){
+Symbols::Symbols(const vec_str_t &symbs, const set_str_t &unique_symbs): symbols(symbs){
     symb_ids = new unsigned int[symbs.size()];
     unsigned int current_id = 0;
-    for (const string &symb: unique_symbs)
+    for (auto iter=unique_symbs.begin(); iter != unique_symbs.end(); ++iter)
     {
-        symb_id_translation[symb] = current_id++;
+        symb_id_translation[*iter] = current_id++;
     }
 
     // Populate the symb_id array
-    for (unsigned int i=0;i<symbs.size();i++)
-    {
-        symb_ids[i] = symb_id_translation[symbs[i]];
-    }
+    update_ids();
+}
+
+Symbols::Symbols(const Symbols &other)
+{
+    other.swap(*this);
+}
+
+Symbols& Symbols::operator=(const Symbols &other){
+    other.swap(*this);
+    return *this;
 }
 
 bool Symbols::is_consistent() const
@@ -38,4 +46,28 @@ void Symbols::set_symbol(unsigned int indx, const string &new_symb)
 {
     symbols[indx] = new_symb;
     symb_ids[indx] = symb_id_translation[new_symb];
+}
+
+void Symbols::set_symbols(const vec_str_t &new_symbs){
+    delete [] symb_ids;
+    symb_ids = new unsigned int[new_symbs.size()];
+    symbols = new_symbs;
+    update_ids();
+}
+
+void Symbols::update_ids()
+{
+    for (unsigned int i=0;i<symbols.size();i++)
+    {
+        symb_ids[i] = symb_id_translation[symbols[i]];
+    }
+}
+
+void Symbols::swap(Symbols &other) const{
+    other.symbols = symbols;
+    other.symb_id_translation = symb_id_translation;
+
+    delete [] other.symb_ids;
+    other.symb_ids = new unsigned int[symbols.size()];
+    memcpy(other.symb_ids, symb_ids, symbols.size()*sizeof(unsigned int));
 }

--- a/cpp/src/wang_landau_sampler.cpp
+++ b/cpp/src/wang_landau_sampler.cpp
@@ -523,7 +523,6 @@ void WangLandauSampler::run_until_valid_energy( double emin, double emax )
       {
         updaters[0]->clear_history();
         current_bin[0] = bin;
-        update_atom_position_track(0,change,select1,select2);
       }
       else
       {
@@ -538,7 +537,6 @@ void WangLandauSampler::run_until_valid_energy( double emin, double emax )
       {
         updaters[0]->clear_history();
         current_bin[0] = bin;
-        update_atom_position_track(0,change,select1,select2);
       }
       else
       {

--- a/cpp/src/wang_landau_sampler.cpp
+++ b/cpp/src/wang_landau_sampler.cpp
@@ -254,7 +254,7 @@ void WangLandauSampler::step()
     updaters[uid]->undo_changes();
     if ( is_first[uid] ) return;
 
-    int num_active = histogram->get_number_of_active_bins()
+    int num_active = histogram->get_number_of_active_bins();
     if (bin > num_active) update_current();
     return;
   }

--- a/cpp/src/wang_landau_sampler.cpp
+++ b/cpp/src/wang_landau_sampler.cpp
@@ -247,7 +247,6 @@ void WangLandauSampler::step()
   avg_bin_change += abs(bin-current_bin[uid]);
   //cout << bin << " " << current_bin[uid] << endl;
 
-  bool inside_range = histogram->bin_in_range(bin);
   // Check if the proposed bin is in the sampling range. If not undo changes and return.
   if ( !histogram->bin_in_range(bin) )
   {
@@ -255,7 +254,8 @@ void WangLandauSampler::step()
     updaters[uid]->undo_changes();
     if ( is_first[uid] ) return;
 
-    if ( bin > histogram->get_number_of_active_bins() ) update_current();
+    int num_active = histogram->get_number_of_active_bins()
+    if (bin > num_active) update_current();
     return;
   }
   else if ( bin == current_bin[uid] )
@@ -478,7 +478,7 @@ void WangLandauSampler::run_until_valid_energy( double emin, double emax )
 
       // Update the updaters. Set all processors outside the energy range equal
       // to the proc_in_valid_state
-      for ( int i=0;i<current_bin.size();i++ )
+      for (unsigned int i=0;i<current_bin.size();i++)
       {
         if ( histogram->bin_in_range(current_bin[i]) ) continue;
 
@@ -576,9 +576,6 @@ void WangLandauSampler::run_until_valid_energy( double emin, double emax )
 
 void WangLandauSampler::use_adaptive_windows( unsigned int minimum_window_width )
 {
-  unsigned int Nbins = histogram->get_nbins();
-  double Emin = histogram->get_emin();
-  double Emax = histogram->get_emax();
   Histogram *new_histogram = new AdaptiveWindowHistogram( *histogram, minimum_window_width, *this );
   delete histogram;
   histogram = new_histogram;
@@ -607,21 +604,6 @@ void WangLandauSampler::set_updaters( const vector<CEUpdater*> &new_updaters, li
     updaters[i]->set_atom_position_tracker(atom_positions_track[i]); // This line should not be nessecary, just in case
   }
   current_bin = new_current_bin;
-}
-
-void WangLandauSampler::update_atom_position_track( unsigned int uid, array<SymbolChange,2> &change, unsigned int select1, unsigned int select2 )
-{
-  const string& symb1_old = change[0].old_symb;
-  const string& symb2_old = change[1].old_symb;
-  unsigned int indx1 = change[0].indx;
-  unsigned int indx2 = change[1].indx;
-
-  // NOTE: The following lines are commentet because the
-  // CEupdater updates the tracker.
-  // This function will be removed in the future
-
-  //atom_positions_track[uid][symb1_old][select1] = indx2;
-  //atom_positions_track[uid][symb2_old][select2] = indx1;
 }
 
 double WangLandauSampler::get_mc_time() const

--- a/cpp/src/wang_landau_sampler.cpp
+++ b/cpp/src/wang_landau_sampler.cpp
@@ -62,7 +62,7 @@ WangLandauSampler::WangLandauSampler(PyObject *atoms, PyObject *BC, PyObject *co
     {
       throw invalid_argument("Expected list when parsing position track!");
     }
-    int size = PyList_Size(value);
+    int size = list_size(value);
     for ( int i=0;i<size;i++ )
     {
       pos.push_back( py2int(PyList_GetItem(value,i)) );
@@ -106,7 +106,7 @@ WangLandauSampler::WangLandauSampler(PyObject *atoms, PyObject *BC, PyObject *co
     throw invalid_argument("Expected list when parsing site_types!");
   }
 
-  int size = PyList_Size(py_site_types);
+  int size = list_size(py_site_types);
   for ( int i=0;i<size;i++ )
   {
     site_types.push_back( py2int( PyList_GetItem(py_site_types,i)) );
@@ -119,7 +119,7 @@ WangLandauSampler::WangLandauSampler(PyObject *atoms, PyObject *BC, PyObject *co
     throw invalid_argument("Expected list when parsing symbols!");
   }
 
-  size = PyList_Size( py_symbols );
+  size = list_size( py_symbols );
   for ( int i=0;i<size;i++ )
   {
     symbols.push_back( py2string(PyList_GetItem(py_symbols,i)) );

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ from Cython.Build import cythonize
 1. To parallelize the update of correlation functions
     usng openMP run the installation with
     pip install --install-option="--PARALLEL_CF_UPDATE"
+2. To compile with -g flag use
+   --install-option="--DEBUG"
 """
 
 src_folder = "cpp/src"
@@ -28,11 +30,15 @@ ce_updater_sources = [src_folder+"/"+srcfile for srcfile in ce_updater_sources]
 ce_updater_sources.append("cemc/cpp_ext/cemc_cpp_code.pyx")
 
 define_macros = []
+extra_comp_args = ["-std=c++11", "-fopenmp"]
 extracted_args = []
 for arg in sys.argv:
     if arg == "--PARALLEL_CF_UPDATE":
         define_macros.append(("PARALLEL_CF_UPDATE", None))
         extracted_args.append(arg)
+    elif arg == "--DEBUG":
+        extracted_args.append(arg)
+        extra_comp_args.append("-g")
 
 # Filter out of sys.argv
 for arg in extracted_args:
@@ -40,7 +46,7 @@ for arg in extracted_args:
 
 cemc_cpp_code = Extension("cemc_cpp_code", sources=ce_updater_sources,
                           include_dirs=[inc_folder, np.get_include()],
-                          extra_compile_args=["-std=c++11", "-fopenmp"],
+                          extra_compile_args=extra_comp_args,
                           language="c++", libraries=["gomp", "pthread"],
                           define_macros=define_macros)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ ce_updater_sources = ["ce_updater.cpp", "cf_history_tracker.cpp",
                       "row_sparse_struct_matrix.cpp", "pair_constraint.cpp",
                       "eshelby_tensor.cpp", "eshelby_sphere.cpp",
                       "eshelby_cylinder.cpp", "init_numpy_api.cpp",
-                      "symbols_with_numbers.cpp"]
+                      "symbols_with_numbers.cpp", "basis_function.cpp"]
 
 ce_updater_sources = [src_folder+"/"+srcfile for srcfile in ce_updater_sources]
 ce_updater_sources.append("cemc/cpp_ext/cemc_cpp_code.pyx")

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ ce_updater_sources = ["ce_updater.cpp", "cf_history_tracker.cpp",
                       "named_array.cpp",
                       "row_sparse_struct_matrix.cpp", "pair_constraint.cpp",
                       "eshelby_tensor.cpp", "eshelby_sphere.cpp",
-                      "eshelby_cylinder.cpp", "init_numpy_api.cpp"]
+                      "eshelby_cylinder.cpp", "init_numpy_api.cpp",
+                      "symbols_with_numbers.cpp"]
 
 ce_updater_sources = [src_folder+"/"+srcfile for srcfile in ce_updater_sources]
 ce_updater_sources.append("cemc/cpp_ext/cemc_cpp_code.pyx")


### PR DESCRIPTION
Optimization of the calculation of spin products. Got rid of the use of maps and vectors in the innermost loop. In addition, compilation wargnins related to initialization out of order and comparing signed and unsigned integers have been removed.